### PR TITLE
add test to check purchase enums count

### DIFF
--- a/src/purchase/__tests__/purchase.test.ts
+++ b/src/purchase/__tests__/purchase.test.ts
@@ -1,7 +1,15 @@
 import { keys, map } from 'ramda';
 import purchase from '../purchase';
+import { PurchaseType } from '../purchase.enum';
 
 test('All purchase keys should contain a valid number', () => {
   const purchaseKeys = keys(purchase);
   map((item: number) => expect(typeof purchaseKeys[item]).toBe('number'));
+});
+
+test('Number of default exports equals number of enums', () => {
+  const enumsCount = Object.keys(PurchaseType).length;
+  const defaultExportsCount = Object.keys(purchase).length;
+
+  expect(defaultExportsCount).toEqual(enumsCount);
 });


### PR DESCRIPTION
**Summary**

- added unit test that checks that the count of items in `purchase.enum.ts` always equals the count of default exports from `purchase.ts`

Resolves https://github.com/NMF-earth/carbon-footprint/issues/17