### PR TITLE
Update food emission factors to Poore & Nemecek 2018 data

### DIFF
--- a/src/food/food.ts
+++ b/src/food/food.ts
@@ -5,35 +5,36 @@
  * impacts through producers and consumers." Science, 360(6392), 987-992.
  * DOI: 10.1126/science.aaq0216
  *
+ * Values sourced via Our World in Data (ourworldindata.org/grapher/ghg-per-kg-poore),
+ * which standardized the supplementary data from the original publication.
  * Meta-analysis covering 570 studies, 38,700 farms, 119 countries.
- * Values are global median kgCO2eq per kg of product.
+ * Values are mean kgCO2eq per kg of product across the supply chain.
  *
  * Previous source: http://www.greeneatz.com/foods-carbon-footprint.html
  */
-const lamb = 24.0;
-const beef = 60.0; /* beef herd; dairy herd beef = 21.1 */
+const lamb = 39.72; /* P&N: Lamb & Mutton */
+const beef = 99.48; /* P&N: Beef (beef herd); dairy herd = 33.30 */
 const redMeat = (lamb + beef) / 2;
-const cheese = 11.0;
-const pork = 7.6;
-const turkey = 6.1; /* P&N does not separate turkey; using poultry value */
-const chicken = 6.1;
+const cheese = 23.88;
+const pork = 12.31; /* P&N: Pig Meat */
+const turkey = 9.87; /* P&N does not separate turkey; using Poultry Meat value */
+const chicken = 9.87; /* P&N: Poultry Meat */
 const whiteMeat = (pork + turkey + chicken) / 3;
-const tuna = 6.1; /* P&N: farmed fish 5.1, wild-caught varies; using 6.1 for large pelagic */
-const fish = 5.1;
-const eggs = 4.7;
-const potatoes = 0.5;
-const rice = 4.0;
-const nuts = 0.3;
-const beans = 1.6; /* P&N: other pulses */
-const tofu = 3.0;
-const vegetables = 0.5; /* P&N: root vegetables 0.4, brassicas 0.5, other veg 0.5 */
-const milk = 3.2;
-const fruit = 0.7; /* P&N: average of citrus 0.4, bananas 0.9, apples 0.4, berries 1.1 */
-const lentils = 0.9;
+const tuna = 13.63; /* P&N: Fish (farmed); wild-caught tuna may differ */
+const fish = 13.63; /* P&N: Fish (farmed) */
+const eggs = 4.67;
+const potatoes = 0.46;
+const rice = 4.45;
+const nuts = 0.43;
+const beans = 1.79; /* P&N: Other Pulses */
+const tofu = 3.16;
+const vegetables = 0.53; /* P&N: Other Vegetables; root veg 0.43, brassicas 0.51 */
+const milk = 3.15;
+const fruit = 1.05; /* P&N: Other Fruit; citrus 0.39, bananas 0.86, apples 0.43 */
+const lentils = 0.98; /* P&N: Peas (closest proxy) */
 
-/* Source: Poore & Nemecek 2018 */
-const coffee = 16.5;
-const chocolate = 18.7; /* P&N: dark chocolate */
+const coffee = 28.53;
+const chocolate = 46.65; /* P&N: Dark Chocolate */
 
 export default {
   coffee,

--- a/src/food/food.ts
+++ b/src/food/food.ts
@@ -1,30 +1,39 @@
-/* Unit: kgCO2eq */
+/* Unit: kgCO2eq per kg of product */
 
-/* http://www.greeneatz.com/foods-carbon-footprint.html */
-const lamb = 39.2;
-const beef = 27.0;
+/*
+ * Source: Poore, J., & Nemecek, T. (2018). "Reducing food's environmental
+ * impacts through producers and consumers." Science, 360(6392), 987-992.
+ * DOI: 10.1126/science.aaq0216
+ *
+ * Meta-analysis covering 570 studies, 38,700 farms, 119 countries.
+ * Values are global median kgCO2eq per kg of product.
+ *
+ * Previous source: http://www.greeneatz.com/foods-carbon-footprint.html
+ */
+const lamb = 24.0;
+const beef = 60.0; /* beef herd; dairy herd beef = 21.1 */
 const redMeat = (lamb + beef) / 2;
-const cheese = 13.5;
-const pork = 12.1;
-const turkey = 10.9;
-const chicken = 6.9;
+const cheese = 11.0;
+const pork = 7.6;
+const turkey = 6.1; /* P&N does not separate turkey; using poultry value */
+const chicken = 6.1;
 const whiteMeat = (pork + turkey + chicken) / 3;
-const tuna = 6.1;
-const fish = tuna;
-const eggs = 4.8;
-const potatoes = 2.9;
-const rice = 2.7;
-const nuts = 2.3;
-const beans = 2.0;
-const tofu = 2.0;
-const vegetables = 2.0;
-const milk = 1.9;
-const fruit = 1.1;
+const tuna = 6.1; /* P&N: farmed fish 5.1, wild-caught varies; using 6.1 for large pelagic */
+const fish = 5.1;
+const eggs = 4.7;
+const potatoes = 0.5;
+const rice = 4.0;
+const nuts = 0.3;
+const beans = 1.6; /* P&N: other pulses */
+const tofu = 3.0;
+const vegetables = 0.5; /* P&N: root vegetables 0.4, brassicas 0.5, other veg 0.5 */
+const milk = 3.2;
+const fruit = 0.7; /* P&N: average of citrus 0.4, bananas 0.9, apples 0.4, berries 1.1 */
 const lentils = 0.9;
 
-/* https://www.bilans-ges.ademe.fr/ */
-const coffee = 3.14;
-const chocolate = 4.87;
+/* Source: Poore & Nemecek 2018 */
+const coffee = 16.5;
+const chocolate = 18.7; /* P&N: dark chocolate */
 
 export default {
   coffee,


### PR DESCRIPTION
## Summary
Updates food emission factors from Green Eatz/ADEME sources to the peer-reviewed Poore & Nemecek 2018 dataset (Science, Vol. 360, 987-992), the most comprehensive meta-analysis of food environmental impacts covering 570 studies, 38,700 farms across 119 countries.

Values sourced directly from the Our World in Data API (indicator 104780, ourworldindata.org/grapher/ghg-per-kg-poore), which standardizes the supplementary data from the original publication.

## Problem
The current emission factors use Green Eatz and ADEME as sources. While directionally correct, several values diverge significantly from the peer-reviewed consensus:

| Food | Current (kgCO2eq/kg) | Updated (P&N 2018) | Difference |
|------|---------------------|---------------------|------------|
| Beef | 27.0 | 99.48 | Understated 3.7x |
| Chocolate | 4.87 | 46.65 | Understated 9.6x |
| Coffee | 3.14 | 28.53 | Understated 9.1x |
| Cheese | 13.5 | 23.88 | Understated 1.8x |
| Fish | 6.1 | 13.63 | Understated 2.2x |
| Potatoes | 2.9 | 0.46 | Overstated 6.3x |
| Vegetables | 2.0 | 0.53 | Overstated 3.8x |
| Nuts | 2.3 | 0.43 | Overstated 5.3x |
| Milk | 1.9 | 3.15 | Understated 1.7x |

These inaccuracies compress the apparent difference between animal and plant products, reducing the accuracy of carbon tracking for users. For example, the old data showed potatoes at 2.9 kgCO2eq vs chicken at 6.9 (2.4x difference), when the real gap is 0.46 vs 9.87 (21.5x difference).

## All Updated Values

| Food | Old Value | New Value | P&N Category |
|------|-----------|-----------|--------------|
| lamb | 39.2 | 39.72 | Lamb & Mutton |
| beef | 27.0 | 99.48 | Beef (beef herd) |
| cheese | 13.5 | 23.88 | Cheese |
| pork | 12.1 | 12.31 | Pig Meat |
| turkey | 10.9 | 9.87 | Poultry Meat |
| chicken | 6.9 | 9.87 | Poultry Meat |
| tuna | 6.1 | 13.63 | Fish (farmed) |
| fish | 6.1 | 13.63 | Fish (farmed) |
| eggs | 4.8 | 4.67 | Eggs |
| chocolate | 4.87 | 46.65 | Dark Chocolate |
| coffee | 3.14 | 28.53 | Coffee |
| potatoes | 2.9 | 0.46 | Potatoes |
| rice | 2.7 | 4.45 | Rice |
| nuts | 2.3 | 0.43 | Nuts |
| beans | 2.0 | 1.79 | Other Pulses |
| tofu | 2.0 | 3.16 | Tofu |
| vegetables | 2.0 | 0.53 | Other Vegetables |
| milk | 1.9 | 3.15 | Milk |
| fruit | 1.1 | 1.05 | Other Fruit |
| lentils | 0.9 | 0.98 | Peas |

## Changes
- Updated all food emission factors to Poore & Nemecek 2018 values via Our World in Data API
- Added source citation with DOI and OWID data reference
- Added inline comments explaining mapping decisions where P&N categories don't map 1:1 to existing food items
- Maintained all existing exports and TypeScript interfaces -- no breaking changes

## Source
Poore, J., & Nemecek, T. (2018). Reducing food's environmental impacts through producers and consumers. *Science*, 360(6392), 987-992. DOI: [10.1126/science.aaq0216](https://doi.org/10.1126/science.aaq0216)

Data accessed via: [Our World in Data - GHG emissions per kg of food](https://ourworldindata.org/grapher/ghg-per-kg-poore)

This is the most widely cited meta-analysis of food environmental impacts, used by Our World in Data, the IPCC, and major environmental agencies worldwide.

## Relates to
- NMF-earth/nmf-app#276 (Accurate values)

## Impact
This library powers the NMF mobile app (iOS + Android). Correcting the emission factors improves carbon tracking accuracy for all users, and more accurately reflects the true climate impact difference between animal and plant-based foods.